### PR TITLE
Add exclude dirs to idea config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,3 +51,11 @@ task wrapper(type: Wrapper) {
     gradleVersion = '3.3'
 }
 
+idea {
+    module {
+        [".gradle",".idea","build"].each {
+            excludeDirs += file("$it")
+        }
+    }
+}
+


### PR DESCRIPTION
when import to intellij, those folders(`".gradle",".idea","build"`) should be excluded