### PR TITLE
add start on first thread to fix start up issue in mac 10.11.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ task run(dependsOn: demoClasses, type: JavaExec) {
     classpath = sourceSets.demo.runtimeClasspath
     standardInput = System.in
     workingDir = "$projectDir/src/demo/resources"
+    jvmArgs = [ '-XstartOnFirstThread']
     ignoreExitValue = true
 }
 


### PR DESCRIPTION
Fix below issue for mac

> Exception in thread "main" java.lang.ExceptionInInitializerError
        at org.lwjgl.glfw.GLFW.glfwCreateWindow(GLFW.java:1384)
        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.createGlfwWindow(Lwjgl3Application.java:425)
        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.createWindow(Lwjgl3Application.java:372)
        at com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application.<init>(Lwjgl3Application.java:107)
        at com.ayocrazy.easystage.view.WindowLauncher.main(WindowLauncher.java:19)
Caused by: java.lang.IllegalStateException: GLFW windows may only be created on the main thread and that thread must be the first thread in the process. Please run the JVM with -XstartOnFirstThread. For offscreen rendering, make sure another window toolkit (e.g. AWT or JavaFX) is initialized before GLFW.
        at org.lwjgl.glfw.EventLoop$OffScreen.<clinit>(EventLoop.java:38)
        ... 5 more
AL lib: (EE) alc_cleanup: 1 device not closed